### PR TITLE
feat: automate deployment to play store closed testing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to Play Store
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need tags to compute the version
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Compute version from tag
+        id: version
+        # v1.0.11 -> versionName 1.0.11, versionCode 10011 (major*10000 + minor*100 + patch),
+        # so the code always increases as long as the tag does.
+        run: |
+          TAG=$(git describe --tags --abbrev=0 --match 'v*')
+          VERSION=${TAG#v}
+          IFS=. read -r MAJOR MINOR PATCH <<< "$VERSION"
+          echo "name=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "code=$((MAJOR * 10000 + MINOR * 100 + PATCH))" >> "$GITHUB_OUTPUT"
+
+      - name: Decode upload keystore
+        run: echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
+
+      - name: Build signed release bundle
+        env:
+          RELEASE_KEYSTORE_PATH: ${{ runner.temp }}/upload-keystore.jks
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: >
+          ./gradlew bundleRelease
+          -PappVersionCode=${{ steps.version.outputs.code }}
+          -PappVersionName=${{ steps.version.outputs.name }}
+
+      - name: Upload to closed testing
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.pizza.vibelauncher
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: alpha
+          status: completed

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      # Only GitHub-official actions are used; the Play upload itself is our
+      # own script (scripts/upload_to_play.py) built on Google's official
+      # client libraries, so no third-party action ever sees credentials.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # need tags to compute the version
@@ -18,8 +21,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-
-      - uses: gradle/actions/setup-gradle@v4
 
       - name: Compute version from tag
         id: version
@@ -47,10 +48,10 @@ jobs:
           -PappVersionName=${{ steps.version.outputs.name }}
 
       - name: Upload to closed testing
-        uses: r0adkll/upload-google-play@v1
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: com.pizza.vibelauncher
-          releaseFiles: app/build/outputs/bundle/release/app-release.aab
-          track: alpha
-          status: completed
+        env:
+          PLAY_CREDENTIALS: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          pip install --quiet 'google-api-python-client==2.160.0' 'google-auth==2.38.0' 'google-auth-httplib2==0.2.0'
+          printf '%s' "$PLAY_CREDENTIALS" > "$RUNNER_TEMP/play-credentials.json"
+          export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/play-credentials.json"
+          python scripts/upload_to_play.py app/build/outputs/bundle/release/app-release.aab alpha

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,10 +12,26 @@ android {
         applicationId = "com.pizza.vibelauncher"
         minSdk = 24
         targetSdk = 35
-        versionCode = 13
-        versionName = "1.0.11"
+        // CI passes the version derived from the release tag; the fallbacks
+        // are only used for local builds.
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toInt() ?: 13
+        versionName = (project.findProperty("appVersionName") as String?) ?: "1.0.11"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    // Signing is configured from the environment so CI can produce signed
+    // bundles; local builds without these variables are unaffected.
+    val releaseKeystorePath = System.getenv("RELEASE_KEYSTORE_PATH")
+    if (releaseKeystorePath != null) {
+        signingConfigs {
+            create("release") {
+                storeFile = file(releaseKeystorePath)
+                storePassword = System.getenv("RELEASE_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("RELEASE_KEY_ALIAS")
+                keyPassword = System.getenv("RELEASE_KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {
@@ -26,6 +42,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            if (releaseKeystorePath != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
     compileOptions {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,7 +2,11 @@
 
 Releases are built and uploaded to the Play Store **closed testing** track
 automatically by the [`deploy.yml`](../.github/workflows/deploy.yml) GitHub
-Actions workflow.
+Actions workflow. The upload itself is done by our own script,
+[`scripts/upload_to_play.py`](../scripts/upload_to_play.py), which uses only
+Google's official client libraries — no third-party GitHub action ever sees
+the signing key or Play credentials. The only actions used are GitHub's own
+(`actions/checkout`, `actions/setup-java`).
 
 ## Releasing a new version
 
@@ -25,16 +29,34 @@ production stays a manual step in Play Console.
 
 ## One-time setup
 
-The workflow needs five repository secrets
-(**Settings → Secrets and variables → Actions**):
+### 1. Create the Play service account
 
-| Secret | Contents |
-| --- | --- |
-| `RELEASE_KEYSTORE_BASE64` | Your **existing** upload keystore, base64 encoded: `base64 -w0 upload-keystore.jks` |
-| `RELEASE_KEYSTORE_PASSWORD` | Keystore password |
-| `RELEASE_KEY_ALIAS` | Key alias inside the keystore |
-| `RELEASE_KEY_PASSWORD` | Key password |
-| `PLAY_SERVICE_ACCOUNT_JSON` | Google Cloud service account JSON key (see below) |
+1. In [Google Cloud Console](https://console.cloud.google.com/), pick (or
+   create) a project and enable the **Google Play Android Developer API**.
+2. Create a service account (IAM & Admin → Service Accounts), then create a
+   **JSON key** for it and download it.
+3. In [Play Console](https://play.google.com/console), go to **Users and
+   permissions → Invite new user**, enter the service account's email address,
+   and grant it access to this app with the **Release to testing tracks**
+   permission only — then even a leaked credential can't touch production.
+
+### 2. Create the repository secrets
+
+Run these on the machine that has your upload keystore (requires the
+[GitHub CLI](https://cli.github.com/); or add them by hand under
+**Settings → Secrets and variables → Actions**):
+
+```sh
+cd vibelauncher
+
+gh secret set RELEASE_KEYSTORE_BASE64 --body "$(base64 -w0 /path/to/upload-keystore.jks)"
+gh secret set RELEASE_KEYSTORE_PASSWORD    # prompts; paste the keystore password
+gh secret set RELEASE_KEY_ALIAS            # prompts; paste the key alias
+gh secret set RELEASE_KEY_PASSWORD         # prompts; paste the key password
+gh secret set PLAY_SERVICE_ACCOUNT_JSON < /path/to/service-account-key.json
+```
+
+(On macOS use `base64 -i` instead of `base64 -w0`.)
 
 > **Important:** the keystore must be the same upload keystore you have been
 > signing releases with until now (the `.jks`/`.keystore` file on your
@@ -46,22 +68,23 @@ The workflow needs five repository secrets
 > lost, Play App Signing lets you request an upload key reset from that same
 > page.
 
-### Creating the service account
+## Security notes
 
-1. In [Google Cloud Console](https://console.cloud.google.com/), pick (or
-   create) a project and enable the **Google Play Android Developer API**.
-2. Create a service account (IAM & Admin → Service Accounts), then create a
-   **JSON key** for it and download it. That file's contents go into the
-   `PLAY_SERVICE_ACCOUNT_JSON` secret.
-3. In [Play Console](https://play.google.com/console), go to **Users and
-   permissions → Invite new user**, enter the service account's email address,
-   and grant it access to this app with the **Release to testing tracks**
-   permission (or the "Release manager" role).
-
-### Notes
-
-- The `track: alpha` in the workflow targets the default closed testing
-  track. If you use a custom closed track, replace `alpha` with the track's
-  name as shown in Play Console.
+- **Track selection**: the workflow uploads to the default closed testing
+  track (`alpha`). If you use a custom closed track, change the track
+  argument in the workflow's upload step to the track's name from Play
+  Console.
+- **Pinning actions**: `actions/checkout` and `actions/setup-java` are
+  referenced by version tag and published by GitHub itself. For extra rigor,
+  pin them to commit SHAs — look up the SHA with
+  `gh api repos/actions/checkout/git/ref/tags/v4 --jq .object.sha` and
+  replace the tag in the workflow with it.
+- **Going keyless (optional)**: `scripts/upload_to_play.py` authenticates via
+  Application Default Credentials, so `PLAY_SERVICE_ACCOUNT_JSON` can hold a
+  Workload Identity Federation credential config instead of a long-lived JSON
+  key. That requires setting up a workload identity pool and GitHub OIDC
+  provider in Google Cloud, plus a step in the workflow that fetches the
+  runner's OIDC token. Worth doing if the key ever becomes a concern; the
+  script needs no changes.
 - The very first upload of an app can't be done through the API — that has
   already happened for this app, so tag away.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,67 @@
+# Releasing
+
+Releases are built and uploaded to the Play Store **closed testing** track
+automatically by the [`deploy.yml`](../.github/workflows/deploy.yml) GitHub
+Actions workflow.
+
+## Releasing a new version
+
+Tag the commit you want to ship and push the tag — that's the whole release:
+
+```sh
+git tag v1.0.11
+git push origin v1.0.11
+```
+
+The version comes from the tag, so there is no gradle file to edit:
+`v1.0.11` becomes `versionName 1.0.11` and
+`versionCode 10011` (`major*10000 + minor*100 + patch`), which is always
+higher than the previous release as long as the tag number goes up.
+
+CI builds a signed `.aab` and uploads it to closed testing. You can also
+trigger the workflow manually from the Actions tab ("Run workflow"); it will
+use the most recent `v*` tag. Promoting a build from closed testing to
+production stays a manual step in Play Console.
+
+## One-time setup
+
+The workflow needs five repository secrets
+(**Settings → Secrets and variables → Actions**):
+
+| Secret | Contents |
+| --- | --- |
+| `RELEASE_KEYSTORE_BASE64` | Your **existing** upload keystore, base64 encoded: `base64 -w0 upload-keystore.jks` |
+| `RELEASE_KEYSTORE_PASSWORD` | Keystore password |
+| `RELEASE_KEY_ALIAS` | Key alias inside the keystore |
+| `RELEASE_KEY_PASSWORD` | Key password |
+| `PLAY_SERVICE_ACCOUNT_JSON` | Google Cloud service account JSON key (see below) |
+
+> **Important:** the keystore must be the same upload keystore you have been
+> signing releases with until now (the `.jks`/`.keystore` file on your
+> laptop). Play only accepts uploads signed with the upload key it already
+> knows for this app — a freshly generated key will be rejected. You can
+> check which key Play expects under **Play Console → Setup → App signing →
+> Upload key certificate**, and compare it to your keystore with
+> `keytool -list -v -keystore upload-keystore.jks`. If the keystore is ever
+> lost, Play App Signing lets you request an upload key reset from that same
+> page.
+
+### Creating the service account
+
+1. In [Google Cloud Console](https://console.cloud.google.com/), pick (or
+   create) a project and enable the **Google Play Android Developer API**.
+2. Create a service account (IAM & Admin → Service Accounts), then create a
+   **JSON key** for it and download it. That file's contents go into the
+   `PLAY_SERVICE_ACCOUNT_JSON` secret.
+3. In [Play Console](https://play.google.com/console), go to **Users and
+   permissions → Invite new user**, enter the service account's email address,
+   and grant it access to this app with the **Release to testing tracks**
+   permission (or the "Release manager" role).
+
+### Notes
+
+- The `track: alpha` in the workflow targets the default closed testing
+  track. If you use a custom closed track, replace `alpha` with the track's
+  name as shown in Play Console.
+- The very first upload of an app can't be done through the API — that has
+  already happened for this app, so tag away.

--- a/scripts/upload_to_play.py
+++ b/scripts/upload_to_play.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Upload an .aab to a Google Play track.
+
+Usage: upload_to_play.py <bundle.aab> <track>
+
+Authenticates via Application Default Credentials: point
+GOOGLE_APPLICATION_CREDENTIALS at either a service-account JSON key or a
+workload-identity-federation credential config. Uses only Google's official
+client libraries.
+"""
+
+import sys
+
+import google.auth
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+PACKAGE_NAME = "com.pizza.vibelauncher"
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <bundle.aab> <track>")
+    aab_path, track = sys.argv[1], sys.argv[2]
+
+    credentials, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/androidpublisher"]
+    )
+    edits = build("androidpublisher", "v3", credentials=credentials).edits()
+
+    edit_id = edits.insert(packageName=PACKAGE_NAME).execute()["id"]
+    print(f"created edit {edit_id}")
+
+    bundle = edits.bundles().upload(
+        packageName=PACKAGE_NAME,
+        editId=edit_id,
+        media_body=MediaFileUpload(aab_path, mimetype="application/octet-stream"),
+    ).execute()
+    version_code = bundle["versionCode"]
+    print(f"uploaded bundle versionCode={version_code}")
+
+    edits.tracks().update(
+        packageName=PACKAGE_NAME,
+        editId=edit_id,
+        track=track,
+        body={"releases": [{"versionCodes": [str(version_code)], "status": "completed"}]},
+    ).execute()
+    print(f"assigned versionCode {version_code} to track '{track}'")
+
+    edits.commit(packageName=PACKAGE_NAME, editId=edit_id).execute()
+    print("edit committed - release is live on the track")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Pushing a version tag (e.g. `v1.0.11`) now builds a signed release bundle and uploads it to the Play Store **closed testing** track automatically — no manual build or upload step, and no gradle version edits.

## How

- **`scripts/upload_to_play.py`** — our own ~50-line upload script using only Google's official client libraries (`google-api-python-client`, `google-auth`, pinned versions): creates a Play edit, uploads the `.aab`, assigns it to the track, commits. No third-party GitHub action ever touches the signing key or Play credentials; the only actions used are GitHub's own (`actions/checkout`, `actions/setup-java`).
- **`.github/workflows/deploy.yml`** — triggers on `v*` tags (or manually from the Actions tab), builds `bundleRelease` signed with the upload keystore from repo secrets, and runs the upload script against the closed testing (`alpha`) track.
- **Version comes from the tag** — `v1.0.11` becomes `versionName 1.0.11` and `versionCode 10011` (`major*10000 + minor*100 + patch`), so the code always increases with the tag and there is nothing to bump by hand. `app/build.gradle.kts` reads these from `-P` properties, falling back to the current static values for local builds.
- **Signing via environment** — `app/build.gradle.kts` picks up an upload keystore from `RELEASE_KEYSTORE_*` env vars when present; local builds without them are completely unaffected.
- **`docs/RELEASING.md`** — release runbook and one-time setup: service-account creation, `gh secret set` commands to create the five repo secrets from the machine that has the upload keystore, a note that the keystore must be the existing upload key (Play rejects any other), optional SHA-pinning of the GitHub actions, and an optional keyless (Workload Identity Federation) path — the script authenticates via Application Default Credentials, so it supports a WIF credential config with no code changes.

## Testing

- `bundleRelease` without signing env vars still builds (unsigned) — local flow unaffected.
- `bundleRelease` with a throwaway keystore via the env vars produces a correctly signed bundle (verified with `keytool -printcert -jarfile`).
- `bundleRelease -PappVersionCode=10011 -PappVersionName=1.0.11` produces a bundle whose manifest carries `1.0.11`.
- The upload script installs with the pinned library versions and correctly loads credentials from `GOOGLE_APPLICATION_CREDENTIALS` (verified locally up to the auth boundary; the actual Play API call can only be exercised with real credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc3tcMZLaaQET7pQUggyPC