### PR TITLE
target android 16 (api 36) for google play requirements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "com.pizza.vibelauncher"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.pizza.vibelauncher"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         // CI passes the version derived from the release tag; the fallbacks
         // are only used for local builds.
         versionCode = (project.findProperty("appVersionCode") as String?)?.toInt() ?: 13


### PR DESCRIPTION
Google Play requires apps to target the latest Android version by **Aug 31, 2026** ("[Action required] Your app is affected by Google Play's target API level requirements"). This bumps `compileSdk` and `targetSdk` from 35 to 36 (Android 16).

Reviewed Android 16 behavior changes for impact on this app:

- **Edge-to-edge**: already enforced since targetSdk 35; the app handles insets via `windowInsetsPadding`/`imePadding`, no opt-outs in use.
- **Predictive back**: minimal relevance for a HOME-category app; no `OnBackPressed` overrides in the codebase.
- **Orientation/resizability changes on large screens**: the app doesn't restrict orientation or resizability.

No code changes required. Both `assembleDebug` and `bundleRelease` build clean against SDK 36 with AGP 8.10.1.

After merging, tag the next release (e.g. `v1.0.14`) and the pipeline will upload the API-36 build to closed testing; promote it to production before the Aug 31 deadline to clear the Play warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uc3tcMZLaaQET7pQUggyPC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uc3tcMZLaaQET7pQUggyPC)_